### PR TITLE
Proposal: test build on multiple java LTS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   build:
+    name: Build with java ${{ matrix.java_version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
         type: string
         required: false
         default: 17
-      java_versions:
+      java_test_versions:
         description: Java versions to use for testing the project
         type: string
         required: false
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java_version: ${{ fromJson(inputs.java_versions) }}
+        java_version: ${{ fromJson(inputs.java_test_versions) }}
     steps:
       - uses: actions/checkout@v3
       - uses: ts-graphviz/setup-graphviz@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
 
   publish-snapshots:
     runs-on: ubuntu-latest
+    needs: build
     if: inputs.publish_snapshots && github.repository_owner == 'jqassistant-plugin' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,15 @@ on:
   workflow_call:
     inputs:
       java_version:
-        description: Java version to use
+        description: Java version to use for publishing artifacts
         type: string
         required: false
         default: 17
+      java_versions:
+        description: Java versions to use for testing the project
+        type: string
+        required: false
+        default: '[11, 17, 21]'
       publish_snapshots:
         description: Whether to attempt publishing snapshots. When false, the workflow will only run build.
         type: boolean
@@ -29,6 +34,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java_version: ${{ fromJson(inputs.java_versions) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ts-graphviz/setup-graphviz@v1
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java_version }}
+          cache: 'maven'
+      - name: test with java ${{ matrix.java_version }}
+        run: mvn --batch-mode --update-snapshots -P IT verify
+
+  publish-snapshots:
+    runs-on: ubuntu-latest
+    if: inputs.publish_snapshots && github.repository_owner == 'jqassistant-plugin' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v3
       - uses: ts-graphviz/setup-graphviz@v1
@@ -43,15 +65,10 @@ jobs:
           gpg-private-key: ${{ secrets.ossrh_signing_key }}
           gpg-passphrase: OSSRH_SIGNING_PASSWORD
 
-      - name: build
-        run: mvn --batch-mode --update-snapshots -P IT verify
-
       - name: publish-snapshots
-        if: inputs.publish_snapshots && github.repository_owner == 'jqassistant-plugin' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-        run: mvn deploy --batch-mode -P release,sonar
+        run: mvn deploy --batch-mode -P release,sonar -DskipTests
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           OSSRH_SIGNING_PASSWORD: ${{ secrets.OSSRH_SIGNING_PASSWORD }}
           SONARCLOUD_LOGIN: ${{ secrets.SONAR_TOKEN }}
-          


### PR DESCRIPTION
The idea is to test the build with multiple java versions, using job matrix feature proposed by github actions.
By default I propose to test on java versions 11, 17 and 21.
Plugin that only run on java 17+ (such as spring plugin) could override the default.

You can see an example of run here: https://github.com/murdos/jqassistant-jmolecules-plugin/pull/3